### PR TITLE
slider/time issue

### DIFF
--- a/core/javascript/jquery.player.js
+++ b/core/javascript/jquery.player.js
@@ -105,14 +105,8 @@ var html5_methods = {
 		getDuration : function(){return this.player.duration;},
 		getCurrentTime : function(){return this.player.currentTime;},
 		getBytesLoaded : function(){return this.player.buffered.end(0);},
-		getBytesTotal : function(){
-			if(this.player.seekable != undefined){	
-				return this.player.seekable.end();
-			}else{
-				// Some browsers (Firefox 4) will not always have the seekable property
-				// If not, just return the duration 
+		getBytesTotal : function(){ 
 				return this.player.duration;
-			}
 		},
 		seek : function(time){this.player.currentTime = time;},
 		cue : function(){return;}	// No queueing required for html5 video, just return


### PR DESCRIPTION
When is nomensa playing a file (video or mp3) there are several errors in javascript console related with player.seeking.end() and the sliders doesn't move. However it works perfectly in firefox. I remove the call to this function and it works ok.
